### PR TITLE
Added pattern filter flags to include/exclude schemas and tables

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ const dump = function ({
   password,
   file,
   format = "c",
+  blobs,
+  schema = [],
+  "exclude-schema": excludeSchema = [],
+  table = [],
+  "exclude-table": excludeTable = [],
 }) {
   let args = [];
   if (password) {
@@ -69,6 +74,53 @@ const dump = function ({
   if (format) {
     args.push("--format");
     args.push(format);
+  }
+  if (blobs) {
+    args.push("--blobs");
+  }
+  if (schema) {
+    if (Array.isArray(schema)) {
+      for (item of schema) {
+        args.push("--schema");
+        args.push(item);
+      }
+    } else {
+      args.push("--schema");
+      args.push(schema);
+    }
+  }
+  if (excludeSchema) {
+    if (Array.isArray(excludeSchema)) {
+      for (item of excludeSchema) {
+        args.push("--exclude-schema");
+        args.push(item);
+      }
+    } else {
+      args.push("--exclude-schema");
+      args.push(excludeSchema);
+    }
+  }
+  if (table) {
+    if (Array.isArray(table)) {
+      for (item of table) {
+        args.push("--table");
+        args.push(item);
+      }
+    } else {
+      args.push("--table");
+      args.push(table);
+    }
+  }
+  if (excludeTable) {
+    if (Array.isArray(excludeTable)) {
+      for (item of excludeTable) {
+        args.push("--exclude-table");
+        args.push(item);
+      }
+    } else {
+      args.push("--exclude-table");
+      args.push(excludeTable);
+    }
   }
   return execa(pgDumpPath, args, {});
 };

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const dump = function ({
   "exclude-schema": excludeSchema = [],
   table = [],
   "exclude-table": excludeTable = [],
+  "exclude-table-data": excludeTableData = [],
 }) {
   let args = [];
   if (password) {
@@ -120,6 +121,17 @@ const dump = function ({
     } else {
       args.push("--exclude-table");
       args.push(excludeTable);
+    }
+  }
+  if (excludeTableData) {
+    if (Array.isArray(excludeTableData)) {
+      for (item of excludeTableData) {
+        args.push("--exclude-table-data");
+        args.push(item);
+      }
+    } else {
+      args.push("--exclude-table-data");
+      args.push(excludeTableData);
     }
   }
   return execa(pgDumpPath, args, {});

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,11 @@ async function main() {
     password,
     file: "./test.pgdump",
     format, // defaults to 'c'
+    blobs = true, // default behaviour of pg_dump unless schema(s) specified
+    schema = "my_user_schema", // include in dump specified schema(s)
+    "exclude-schema" = ["public", "another_user_schema"], // exclude from dump specified schema(s)
+    table = "my_user_schema.*", // include matching schema table(s) in example of pg_dump wildcard support
+    "exclude-table" = ["my_user_schema.table_to_skip", "*.metadata"], // exclude specific table(s) or wildcards, overrides inclusion
   }); // outputs an execa object
 
   const { stdout, stderr } = await pgDumpRestore.restore({

--- a/tests/database.mock.js
+++ b/tests/database.mock.js
@@ -22,7 +22,7 @@ let databaseConfig = {
 let sequelize = new Sequelize(databaseConfig);
 
 const TableA = sequelize.define(
-  "tableA",
+  "table_A",
   {
     id: {
       type: Sequelize.STRING,
@@ -42,7 +42,7 @@ const TableA = sequelize.define(
 );
 
 const TableB = sequelize.define(
-  "tableB",
+  "table_B",
   {
     id: {
       type: Sequelize.STRING,
@@ -62,7 +62,7 @@ const TableB = sequelize.define(
 );
 
 const TableC = sequelize.define(
-  "tableC",
+  "table_C",
   {
     id: {
       type: Sequelize.STRING,
@@ -82,7 +82,7 @@ const TableC = sequelize.define(
 );
 
 const TableD = sequelize.define(
-  "tableD",
+  "table_D",
   {
     id: {
       type: Sequelize.STRING,

--- a/tests/database.mock.js
+++ b/tests/database.mock.js
@@ -21,8 +21,8 @@ let databaseConfig = {
 
 let sequelize = new Sequelize(databaseConfig);
 
-const Patient = sequelize.define(
-  "patient",
+const TableA = sequelize.define(
+  "tableA",
   {
     id: {
       type: Sequelize.STRING,
@@ -37,18 +37,100 @@ const Patient = sequelize.define(
     updatedAt: "updated_at",
     deletedAt: "deleted_at",
     paranoid: true,
+    freezeTableName: true,
+  }
+);
+
+const TableB = sequelize.define(
+  "tableB",
+  {
+    id: {
+      type: Sequelize.STRING,
+      primaryKey: true,
+      allowNull: false,
+    },
+    data: { type: Sequelize.JSON },
+    misc: { type: Sequelize.JSON },
+  },
+  {
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+    deletedAt: "deleted_at",
+    paranoid: true,
+    freezeTableName: true,
+  }
+);
+
+const TableC = sequelize.define(
+  "tableC",
+  {
+    id: {
+      type: Sequelize.STRING,
+      primaryKey: true,
+      allowNull: false,
+    },
+    data: { type: Sequelize.JSON },
+    misc: { type: Sequelize.JSON },
+  },
+  {
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+    deletedAt: "deleted_at",
+    paranoid: true,
+    freezeTableName: true,
+  }
+);
+
+const TableD = sequelize.define(
+  "tableD",
+  {
+    id: {
+      type: Sequelize.STRING,
+      primaryKey: true,
+      allowNull: false,
+    },
+    data: { type: Sequelize.JSON },
+    misc: { type: Sequelize.JSON },
+  },
+  {
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+    deletedAt: "deleted_at",
+    paranoid: true,
+    freezeTableName: true,
   }
 );
 
 const populate = async () => {
-  let patient2 = await Patient.create(
-    {
-      id: "p4567",
-      data: { wow: 1 },
-      misc: {},
-    },
-    { user_id: "ME" }
-  );
+  await TableA.create({
+    id: "elementTableA",
+    data: { wow: "A" },
+    misc: {},
+  });
+  await TableB.create({
+    id: "elementTableB",
+    data: { wow: "B" },
+    misc: {},
+  });
+  await TableC.create({
+    id: "elementTableC",
+    data: { wow: "C" },
+    misc: {},
+  });
+  await TableD.create({
+    id: "elementTableD",
+    data: { wow: "D" },
+    misc: {},
+  });
 };
 
-module.exports = { Patient, sequelize, populate, CREDENTIALS };
+module.exports = {
+  TableA,
+  TableB,
+  TableC,
+  TableD,
+
+  sequelize,
+  populate,
+  CREDENTIALS,
+};

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -21,9 +21,10 @@ describe("Can dump and restore database", () => {
       await pgDumpRestore.dump({
         ...database.CREDENTIALS,
         file: "./test_include_exclude_table.pgdump",
-        // table: "tabl*",
-        // table: "'tableA'",
-        excludeTable: "*",
+        table: "tabl*",
+        // schema: "public",
+        // table: ["public.table_A"],
+        excludeTableData: "public.table_*",
       });
       expect(
         await fs.pathExists("./test_include_exclude_table.pgdump")

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -16,20 +16,56 @@ describe("Can dump and restore database", () => {
       });
       expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
     });
+    test("can dump database with table include/exclude", async () => {
+      expect.assertions(1);
+      await pgDumpRestore.dump({
+        ...database.CREDENTIALS,
+        file: "./test_include_exclude_table.pgdump",
+        // table: "tabl*",
+        // table: "'tableA'",
+        excludeTable: "*",
+      });
+      expect(
+        await fs.pathExists("./test_include_exclude_table.pgdump")
+      ).toBeTruthy();
+    });
   });
   describe("Can restore", () => {
     test("can restore database", async () => {
-      expect.assertions(1);
+      expect.assertions(4);
       await database.sequelize.drop();
       await pgDumpRestore.restore({
         ...database.CREDENTIALS,
         filename: "./test.pgdump",
       });
-      allPatients = await database.Patient.findAll();
-      expect(allPatients.length).toBe(1);
+      const tableAElements = await database.TableA.findAll();
+      expect(tableAElements.length).toBe(1);
+      const tableBElements = await database.TableB.findAll();
+      expect(tableBElements.length).toBe(1);
+      const tableCElements = await database.TableC.findAll();
+      expect(tableCElements.length).toBe(1);
+      const tableDElements = await database.TableD.findAll();
+      expect(tableDElements.length).toBe(1);
+    });
+    test("can restore database with table include/exclude", async () => {
+      expect.assertions(4);
+      await database.sequelize.drop();
+      await pgDumpRestore.restore({
+        ...database.CREDENTIALS,
+        filename: "./test_include_exclude_table.pgdump",
+      });
+      const tableAElements = await database.TableA.findAll();
+      expect(tableAElements.length).toBe(1);
+      const tableBElements = await database.TableB.findAll();
+      expect(tableBElements.length).toBe(1);
+      const tableCElements = await database.TableC.findAll();
+      expect(tableCElements.length).toBe(1);
+      const tableDElements = await database.TableD.findAll();
+      expect(tableDElements.length).toBe(1);
     });
   });
   afterAll(async () => {
     await fs.remove("./test.pgdump");
+    await fs.remove("./test_include_exclude_table.pgdump");
   });
 });


### PR DESCRIPTION
Adds support for [the filter flags](https://www.postgresql.org/docs/13/app-pgdump.html#PG-DUMP-OPTIONS) to include and exclude specific schemas and tables, allowing for selective backups:

```javascript
pg.dump({
  // ...other options omitted
  schema: "my_schema",
  "exclude-schema": ["not_my_schema","public"],
  table: "my_schema.*",
  "exclude-table": ["my_schema.metadata_table", "my_schema.generated_data"],
});
```

Also added support for the boolean `blob` flag to dump non-schema blob objects (which is the default unless `--schema` flag is provided).