### PR TITLE
:sparkles: Add Verbose Argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,16 +76,10 @@ const dump = function ({
   }
 
   const subprocess = execa(pgDumpPath, args, {});
+  subprocess.stdout.on('data', checkError);
+  subprocess.stderr.on('data', checkError);
 
-  subprocess.stdout.on('data', (data) => {
-    console.log(data.toString().trim());
-  });
-
-  subprocess.stderr.on('data', (data) => {
-    console.info(data.toString().trim());
-  });
-
-  return subprocess; 
+  return subprocess;
 };
 const restore = function ({
   port = 5432,
@@ -141,22 +135,27 @@ const restore = function ({
     throw new Error("Needs filename in the options");
   }
   args.push(filename);
-  
+
   if (verbose) {
     args.push("--verbose");
   }
 
   const subprocess = execa(pgRestorePath, args, {});
+  subprocess.stdout.on('data', checkError);
+  subprocess.stderr.on('data', checkError);
 
-  subprocess.stdout.on('data', (data) => {
-    console.log(data.toString().trim());
-  });
-
-  subprocess.stderr.on('data', (data) => {
-    console.info(data.toString().trim());
-  });
-
-  return subprocess;  
+  return subprocess;
 };
+
+const checkError = (data) => {
+
+  const message = data.toString().trim();
+  if (message.includes('error:')) {
+    console.error(message);
+  } else {
+    console.info(message);
+  }
+
+}
 
 module.exports = { dump, restore, pgRestorePath, pgDumpPath };

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const dump = function ({
   dbname,
   username,
   password,
+  verbose,
   file,
   format = "c",
 }) {
@@ -70,7 +71,21 @@ const dump = function ({
     args.push("--format");
     args.push(format);
   }
-  return execa(pgDumpPath, args, {});
+  if (verbose) {
+    args.push("--verbose");
+  }
+
+  const subprocess = execa(pgDumpPath, args, {});
+
+  subprocess.stdout.on('data', (data) => {
+    console.log(data.toString().trim());
+  });
+
+  subprocess.stderr.on('data', (data) => {
+    console.info(data.toString().trim());
+  });
+
+  return subprocess; 
 };
 const restore = function ({
   port = 5432,
@@ -78,6 +93,7 @@ const restore = function ({
   dbname,
   username,
   password,
+  verbose,
   filename,
   clean,
   create,
@@ -125,7 +141,22 @@ const restore = function ({
     throw new Error("Needs filename in the options");
   }
   args.push(filename);
-  return execa(pgRestorePath, args, {});
+  
+  if (verbose) {
+    args.push("--verbose");
+  }
+
+  const subprocess = execa(pgRestorePath, args, {});
+
+  subprocess.stdout.on('data', (data) => {
+    console.log(data.toString().trim());
+  });
+
+  subprocess.stderr.on('data', (data) => {
+    console.info(data.toString().trim());
+  });
+
+  return subprocess;  
 };
 
 module.exports = { dump, restore, pgRestorePath, pgDumpPath };

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ async function main() {
     host,
     dbname,
     username,
+    verbose: true, // defaults to false
     password,
     file: "./test.pgdump",
     format, // defaults to 'c'
@@ -26,6 +27,7 @@ async function main() {
     dbname,
     username,
     password,
+    verbose: true, // defaults to false
     filename: "./test.pgdump", // note the filename instead of file, following the pg_restore naming.
     clean, // defaults to false
     create, // defaults to false

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -7,40 +7,62 @@ describe("Can dump and restore database", () => {
     await database.sequelize.sync({ force: true });
     await database.populate();
   });
-  describe("Can dump", () => {
-    test("can dump database", async () => {
-      expect.assertions(1);
-      await pgDumpRestore.dump({
-        ...database.CREDENTIALS,
-        file: "./test.pgdump",
-      });
-      expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
+  test("can dump database", async () => {
+
+    const log = await pgDumpRestore.dump({
+      ...database.CREDENTIALS,
+      file: "./test.pgdump",
     });
+
+    expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
+    expect(log.stderr.includes('pg_dump:')).toBeFalsy();
+
   });
-  describe("Can dump (with verbose)", () => {
-    test("can dump database", async () => {
-      expect.assertions(1);
-      await pgDumpRestore.dump({
-        ...database.CREDENTIALS,
-        verbose: true,
-        file: "./test.pgdump",
-      });
-      expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
+  test("can restore database", async () => {
+
+    await database.sequelize.drop();
+    const log = await pgDumpRestore.restore({
+      ...database.CREDENTIALS,
+      filename: "./test.pgdump",
     });
-  });
-  describe("Can restore", () => {
-    test("can restore database", async () => {
-      expect.assertions(1);
-      await database.sequelize.drop();
-      await pgDumpRestore.restore({
-        ...database.CREDENTIALS,
-        filename: "./test.pgdump",
-      });
-      allPatients = await database.Patient.findAll();
-      expect(allPatients.length).toBe(1);
-    });
-  });
-  afterAll(async () => {
-    await fs.remove("./test.pgdump");
+    allPatients = await database.Patient.findAll();
+    expect(allPatients.length).toBe(1);
+    expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
+    expect(log.stderr.includes('pg_restore:')).toBeFalsy();
   });
 });
+describe("Can dump and restore database (with verbose)", () => {
+  beforeAll(async () => {
+    await database.sequelize.sync({ force: true });
+    await database.populate();
+  });
+  test("can dump database (With verbose)", async () => {
+
+    const log = await pgDumpRestore.dump({
+      ...database.CREDENTIALS,
+      verbose: true,
+      file: "./test.pgdump",
+    });
+
+    expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
+    expect(log.stderr.includes('pg_dump:')).toBeTruthy();
+
+  });
+
+  test("can restore database (with verbose)", async () => {
+
+    await database.sequelize.drop();
+    const log = await pgDumpRestore.restore({
+      ...database.CREDENTIALS,
+      verbose: true,
+      filename: "./test.pgdump",
+    });
+    allPatients = await database.Patient.findAll();
+    expect(allPatients.length).toBe(1);
+    expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
+    expect(log.stderr.includes('pg_restore:')).toBeTruthy();
+  });
+});
+afterAll(async () => {
+  await fs.remove("./test.pgdump");
+}); 

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -17,6 +17,17 @@ describe("Can dump and restore database", () => {
       expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
     });
   });
+  describe("Can dump (with verbose)", () => {
+    test("can dump database", async () => {
+      expect.assertions(1);
+      await pgDumpRestore.dump({
+        ...database.CREDENTIALS,
+        verbose: true,
+        file: "./test.pgdump",
+      });
+      expect(await fs.pathExists("./test.pgdump")).toBeTruthy();
+    });
+  });
   describe("Can restore", () => {
     test("can restore database", async () => {
       expect.assertions(1);


### PR DESCRIPTION
Add ability to use the 'verbose' argument that allows printing stdout and stderr in real-time, without needing to collect the output after the entire execution.

![image](https://github.com/user-attachments/assets/3ea293c6-c5f9-4b2f-9d98-3842f03d995d)
