### PR TITLE
✨Add Disable Triggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,17 @@ const restore = function ({
   disableTriggers
 }) {
   let args = [];
+  
+  if (clean) {
+    args.push("--clean");
+  }
+  if (create) {
+    args.push("--create");
+  } 
+  if (disableTriggers) {
+    args.push("--disable-triggers");
+  }
+  
   if (password) {
     if (!(username && password && host && port && dbname)) {
       throw new Error(
@@ -116,15 +127,6 @@ const restore = function ({
     }
   }
 
-  if (clean) {
-    args.push("--clean");
-  }
-  if (create) {
-    args.push("--create");
-  } 
-  if (disableTriggers) {
-    args.push("--disable-triggers");
-  }
   if (!filename) {
     throw new Error("Needs filename in the options");
   }

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ const restore = function ({
   filename,
   clean,
   create,
+  disableTriggers
 }) {
   let args = [];
   if (password) {
@@ -120,6 +121,9 @@ const restore = function ({
   }
   if (create) {
     args.push("--create");
+  } 
+  if (disableTriggers) {
+    args.push("--disable-triggers");
   }
   if (!filename) {
     throw new Error("Needs filename in the options");

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ async function main() {
     username,
     password,
     filename: "./test.pgdump", // note the filename instead of file, following the pg_restore naming.
+    disableTriggers, // defaults to false
     clean, // defaults to false
     create, // defaults to false
   }); // outputs an execa object


### PR DESCRIPTION
Add: Disable Triggers Argument

> --disable-triggers
This option is relevant only when performing a data-only restore. It instructs pg_restore to execute commands to temporarily disable triggers on the target tables while the data is restored. Use this if you have referential integrity checks or other triggers on the tables that you do not want to invoke during data restore. 

