### PR TITLE
Adds Linux OS support

### DIFF
--- a/bin/linux/bin/pg_dump
+++ b/bin/linux/bin/pg_dump
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pg_dump "$@"

--- a/bin/linux/bin/pg_restore
+++ b/bin/linux/bin/pg_restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pg_restore "$@"

--- a/index.js
+++ b/index.js
@@ -1,7 +1,15 @@
 const execa = require("execa");
 const path = require("path");
 
-let os = process.platform === "win32" ? "win" : "macos";
+let os = "macos";
+switch (process.platform) {
+  case "win32":
+    os = "win";
+    break;
+  case "linux":
+    os = "linux";
+    break;
+}
 
 let binariesPath = path.join(
   __dirname.replace("app.asar", "app.asar.unpacked"),
@@ -81,20 +89,20 @@ const restore = function ({
   filename,
   clean,
   create,
-  disableTriggers
+  disableTriggers,
 }) {
   let args = [];
-  
+
   if (clean) {
     args.push("--clean");
   }
   if (create) {
     args.push("--create");
-  } 
+  }
   if (disableTriggers) {
     args.push("--disable-triggers");
   }
-  
+
   if (password) {
     if (!(username && password && host && port && dbname)) {
       throw new Error(

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A very basic nodejs wrapper around the pg_dump and pg_restore",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --detectOpenHandles"
   },
   "publishConfig": {
     "registry":"https://npm.pkg.github.com"

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ This very small utility that includes pg_dump and pg_restore binaries for Window
 
 A thin CLI wrapper is also provided.
 
+For Linux systems, `pg_dump` and `pg_restore` are simply executed directly from your local system. Compatibility is not guaranteed! Read more in the [Linux support section](#linux-support).
+
 ## Usage
 
 ```js
@@ -52,19 +54,28 @@ I did not use the tool to bundle the dependencies as it would corrupt the execut
 
 I used https://github.com/lucasg/Dependencies to determine the required DLL, filtering only the local dependencies.
 
-
-
 ## To publish to GHCR
 
 Add this to `package.json`
+
 ```json
   "publishConfig": {
     "registry":"https://npm.pkg.github.com"
   },
 ```
 
-and add a `.npmrc` to the root of the repo with 
+and add a `.npmrc` to the root of the repo with
+
 ```.npmrc
 //npm.pkg.github.com/:_authToken=AUTH_TOKEN
 ```
+
 Where `AUTH_TOKEN` is replaced with a GitHub token.
+
+## Linux support
+
+**Currently, only Postgres 13 is supported.** Other versions _may_ work.
+
+Linux support is implemented by simply running a `/bin/sh` script that calls `pg_dump` or `pg_restore`. The scripts are located at `bin/linux/bin/`.
+
+This implementation relies on `pg_dump` and `pg_restore` being accessible via the `$PATH` environment variable.


### PR DESCRIPTION
Provides support for Linux systems by adding basic shell scripts for `pg_dump` and `pg_restore`. Without this change, it is not possible to run a project leveraging this package that isn't running Windows/Mac.

Other changes:

- Minor code formatting/clean up change (via `prettier`/unneeded whitespace removal).
- Adds a tweak to `jest` so that it actually waits for the async calls within test cases to finish. You just have to wait a couple seconds and the tests will complete as expected. It fixes this warning:

    ```text
    Jest did not exit one second after the test run has completed.

    This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
    ```

- Updates the readme to include notes about Linux support. Also a couple newlines for markdown syntax/formatting improvements.

---

Testing notes:

- I have successfully tested this using a containerized environment running a `postgres:13` container image
- Also successful on a Fedora 41 VM (which happens to run `pg_dump` and `pg_restore` version 16). 
- Unsuccessful on Arch Linux - the version is currently 17, which doesn't seem to work:

    ```text
    pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
    Command was: SET transaction_timeout = 0;
    pg_restore: warning: errors ignored on restore: 1
    ````

    The dump test succeeds, but the restore test fails with the above error. This can be resolved by using a containerized environment with a different version of postgres. If you are using Arch Linux, you are probably capable of resolving this on your own.

---

Note: Instead of packaging a precompiled binary, the Linux platform support option leaves it up to the caller's environment to determine the version of the binaries themselves.

This allows developers to control the version of `pg_dump` and `pg_restore` by simply altering their `$PATH` environment variable, or through other creative means, if desired.

This at least offers a basic level of compatibility with Linux systems, but may not philosophically align with this package (it will offer no precompiled binaries for Linux, but it will for mac/win).

---

_Note: please feel free to squash & merge my PR_